### PR TITLE
fix: 解决el-menu默认选中问题

### DIFF
--- a/src/layout/components/Sidebar/Sidebar.vue
+++ b/src/layout/components/Sidebar/Sidebar.vue
@@ -61,12 +61,12 @@ import { useAppStore } from '@/store/app'
 import { usePermissionStore } from '@/store/permission'
 const scssJson = dillScssExportToJson(scssExportJson)
 const activeMenu = computed(() => {
-  const { meta, fullPath } = route
+  const { meta, path } = route
   // if set path, the sidebar will highlight the path you set
   if (meta.activeMenu) {
     return meta.activeMenu
   }
-  return fullPath
+  return path
 })
 </script>
 


### PR DESCRIPTION
如果url地址上带着问号等参数，左侧的菜单栏就不会选中